### PR TITLE
mark/space parity and custom baudrates

### DIFF
--- a/serialport/src/main/cpp/SerialPort.h
+++ b/serialport/src/main/cpp/SerialPort.h
@@ -17,6 +17,14 @@ JNIEXPORT jobject JNICALL Java_android_serialport_SerialPort_open
 
 /*
  * Class:     android_serialport_SerialPort
+ * Method:    setParity
+ * Signature: (Ljava/lang/String;I)Ljava/io/FileDescriptor;
+ */
+JNIEXPORT void JNICALL
+Java_android_serialport_SerialPort_setParity(JNIEnv *, jobject, jstring, jint);
+
+/*
+ * Class:     android_serialport_SerialPort
  * Method:    close
  * Signature: ()V
  */

--- a/serialport/src/main/java/android/serialport/SerialPort.java
+++ b/serialport/src/main/java/android/serialport/SerialPort.java
@@ -42,12 +42,12 @@ public final class SerialPort {
     public static final String DEFAULT_SU_PATH = "/system/bin/su";
 
     private static String sSuPath = DEFAULT_SU_PATH;
-    private final File device;
-    private final int baudrate;
-    private final int dataBits;
-    private final int parity;
-    private final int stopBits;
-    private final int flags;
+    private File device;
+    private int baudrate;
+    private int dataBits;
+    private int parity;
+    private int stopBits;
+    private int flags;
 
     /**
      * Set the su binary path, the default su binary path is {@link #DEFAULT_SU_PATH}
@@ -198,6 +198,7 @@ public final class SerialPort {
     /** Change parity */
     public void changeParity(File device, int parity){
         setParity(device.getAbsolutePath(), parity);
+        this.parity = parity;
     }
 
     // JNI

--- a/serialport/src/main/java/android/serialport/SerialPort.java
+++ b/serialport/src/main/java/android/serialport/SerialPort.java
@@ -27,19 +27,27 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
+
+
 public final class SerialPort {
+
+    public static final int Parity_None = 0;
+    public static final int Parity_Odd  = 1;
+    public static final int Parity_Even = 2;
+    public static final int Parity_Space= 3;
+    public static final int Parity_Mark = 4;
 
     private static final String TAG = "SerialPort";
 
     public static final String DEFAULT_SU_PATH = "/system/bin/su";
 
     private static String sSuPath = DEFAULT_SU_PATH;
-    private File device;
-    private int baudrate;
-    private int dataBits;
-    private int parity;
-    private int stopBits;
-    private int flags;
+    private final File device;
+    private final int baudrate;
+    private final int dataBits;
+    private final int parity;
+    private final int stopBits;
+    private final int flags;
 
     /**
      * Set the su binary path, the default su binary path is {@link #DEFAULT_SU_PATH}
@@ -66,9 +74,9 @@ public final class SerialPort {
     /*
      * Do not remove or rename the field mFd: it is used by native method close();
      */
-    private FileDescriptor mFd;
-    private FileInputStream mFileInputStream;
-    private FileOutputStream mFileOutputStream;
+    private final FileDescriptor mFd;
+    private final FileInputStream mFileInputStream;
+    private final FileOutputStream mFileOutputStream;
 
     /**
      * 串口
@@ -187,9 +195,17 @@ public final class SerialPort {
         return flags;
     }
 
+    /** Change parity */
+    public void changeParity(File device, int parity){
+        setParity(device.getAbsolutePath(), parity);
+    }
+
     // JNI
     private native FileDescriptor open(String absolutePath, int baudrate, int dataBits, int parity,
         int stopBits, int flags);
+
+    // JNI
+    private native void setParity(String absolutePath, int parity);
 
     public native void close();
 
@@ -228,8 +244,8 @@ public final class SerialPort {
 
     public final static class Builder {
 
-        private File device;
-        private int baudrate;
+        private final File device;
+        private final int baudrate;
         private int dataBits = 8;
         private int parity = 0;
         private int stopBits = 1;


### PR DESCRIPTION
Added mark and space parity using the CMSPAR flag in combination with the PARODD flag. Added custom baudrate using the termios2 structure instead of the termios header. Added function to change the parity of a port given the device File and the parity. Added constants to set parity easier (example.. Parity_Even instead of 2).

I don't think it will conflict with the sample application, but maybe you can do something with these changes